### PR TITLE
Fix Reply Button Logic

### DIFF
--- a/src/components/ThreadComponent.tsx
+++ b/src/components/ThreadComponent.tsx
@@ -417,7 +417,7 @@ const ThreadComponent = ({
           <MediumText>&#8196;{dislikesCount}&#8195;</MediumText>
           <ModeCommentOutlinedIcon />
           <MediumText>&#8196;</MediumText>
-          <ReplyText onClick={openReplyInputField}>Reply</ReplyText>
+          <ReplyText onClick={isLoggedIn(token, userId) ? openReplyInputField : showLogInModal}>Reply</ReplyText>
         </VerticalCenterAlignLayout>
         {/* Notes: parent id for thread component is set to 0, equivalent for null */}
         {openReply ? (

--- a/src/pages/QuestionPage.tsx
+++ b/src/pages/QuestionPage.tsx
@@ -139,11 +139,11 @@ const QuestionPage = () => {
                   threadId={thread.Id}
                   level={0}
                 />
-                (isLoggedIn(token, userId) ?{" "}
+                {isLoggedIn(token, userId) ?
                 <EditorContainerDiv>
                   <ReplyTextEditor id={0} threadId={thread.Id} />
-                </EditorContainerDiv>{" "}
-                : <GuestBox />)
+                </EditorContainerDiv>
+                : <GuestBox />}
               </>
             ) : isLoggedIn(token, userId) ? (
               <ThreadContainerDiv>


### PR DESCRIPTION
- Fix parentheses bug in `QuestionPage`
- Update reply button in the following snippet so when a user hasn't logged in, the login modal will be shown instead of the reply editor

![image](https://github.com/PINUSTECH-2022/pinus-study-frontend/assets/96954436/f048eb0c-3ffe-4d41-88d1-1a9b959aefa5)
